### PR TITLE
Support parsing of simple gcc errors

### DIFF
--- a/lib/Message.js
+++ b/lib/Message.js
@@ -8,8 +8,8 @@ Message.prototype.fromGcc = function fromGcc(components, stdout) {
 	this.column = parseInt(components[3]);
 	this.type = components[4];
 	this.text = components[5];
-	this.codeWhitespace = components[6];
-	this.code = components[7];
+	this.codeWhitespace = components[6] ? components[6] : '';
+	this.code = components[7] ? components[7] : '';
 
 	this.adjustedColumn = this.column - this.codeWhitespace.length;
 	this.startIndex = stdout.indexOf(components[0]);

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,10 @@ module.exports = {
 	},
 
 	parseGcc: function parseGcc(stdout) {
-		var regex = /([^:^\n]+):(\d+):(\d+):\s(\w+\s*\w*):\s(.+)\n(\s+)(.*)\s+\^+/gm;
+		var messages = [];
+		var match = null;
+
+		var deepRegex = /([^:^\n]+):(\d+):(\d+):\s(\w+\s*\w*):\s(.+)\n(\s+)(.*)\s+\^+/gm;
 		//            ^          ^     ^       ^       ^     ^    ^
 		//            |          |     |       |       |     |    +- affected code
 		//            |          |     |       |       |     +- whitespace before code
@@ -23,10 +26,21 @@ module.exports = {
 		//            |          |     +- column
 		//            |          +- line
 		//            +- filename
+		while (match = deepRegex.exec(stdout)) {
+			messages.push(new Message().fromGcc(match, stdout));
+		}
 
-		var messages = [];
-		var match = null;
-		while (match = regex.exec(stdout)) {
+		var simpleRegex = /([^:^\n]+):(\d+):(\d+):\s(\w+\s*\w*):\s(.+)\n(?!\s)/gm;
+		//            ^          ^     ^       ^       ^     ^    ^
+		//            |          |     |       |       |     |    +- affected code
+		//            |          |     |       |       |     +- whitespace before code
+		//            |          |     |       |       +- message text
+		//            |          |     |       +- type (error|warning|note)
+		//            |          |     +- column
+		//            |          +- line
+		//            +- filename
+		match = null;
+		while (match = simpleRegex.exec(stdout)) {
 			messages.push(new Message().fromGcc(match, stdout));
 		}
 

--- a/spec/8_dray_0.6.0.txt
+++ b/spec/8_dray_0.6.0.txt
@@ -1,0 +1,61 @@
+Processing  emptyerror.ino
+Checking library Adafruit_LEDBackpack_RK...
+Installing library Adafruit_LEDBackpack_RK 1.1.6 to lib/Adafruit_LEDBackpack_RK ...
+Library Adafruit_LEDBackpack_RK 1.1.6 installed.
+Checking library Adafruit_GFX_RK...
+Installing library Adafruit_GFX_RK 1.1.6 to lib/Adafruit_GFX_RK ...
+Library Adafruit_GFX_RK 1.1.6 installed.
+make -C ../modules/photon/user-part all
+make[1]: Entering directory '/firmware/modules/photon/user-part'
+make -C ../../../user
+make[2]: Entering directory '/firmware/user'
+Building c file: lib/Adafruit_GFX_RK/src/glcdfont.c
+Invoking: ARM GCC C Compiler
+mkdir -p ../build/target/user/platform-6-mAdafruit_GFX_RK/src/
+arm-none-eabi-gcc -DSTM32_DEVICE -DSTM32F2XX -DPLATFORM_THREADING=1 -DPLATFORM_ID=6 -DPLATFORM_NAME=photon -DUSBD_VID_SPARK=0x2B04 -DUSBD_PID_DFU=0xD006 -DUSBD_PID_CDC=0xC006 -DSPARK_PLATFORM -g3 -gdwarf-2 -Os -mcpu=cortex-m3 -mthumb -DINCLUDE_PLATFORM=1 -DPRODUCT_ID=6 -DPRODUCT_FIRMWARE_VERSION=65535 -DUSE_STDPERIPH_DRIVER -DDFU_BUILD_ENABLE -DSYSTEM_VERSION_STRING=0.6.2 -DRELEASE_BUILD -I./inc -I../wiring/inc -I../system/inc -I../services/inc -I../communication/src -I../hal/inc -I../hal/shared -I../hal/src/photon -I../hal/src/stm32f2xx -I../hal/src/stm32 -I../hal/src/photon/api -I../platform/shared/inc -I../platform/MCU/STM32F2xx/STM32_USB_Host_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_OTG_Driver/inc -I../platform/MCU/STM32F2xx/STM32_StdPeriph_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc -I../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc -I../platform/MCU/shared/STM32/inc -I../platform/MCU/STM32F2xx/CMSIS/Include -I../platform/MCU/STM32F2xx/CMSIS/Device/ST/Include -I../dynalib/inc -Isrc -I./libraries -Isrc -Isrc -Isrc -Isrc -Ilib/Adafruit_GFX_RK/src -Ilib/Adafruit_LEDBackpack_RK/src -I. -MD -MP -MF ../build/target/user/platform-6-mAdafruit_GFX_RK/src/glcdfont.o.d -ffunction-sections -fdata-sections -Wall -Wno-switch -Wno-error=deprecated-declarations -fmessage-length=0 -fno-strict-aliasing -DSPARK=1 -DPARTICLE=1 -DSTART_DFU_FLASHER_SERIAL_SPEED=14400 -DSTART_YMODEM_FLASHER_SERIAL_SPEED=28800 -DSPARK_PLATFORM_NET=BCM9WCDUSI09 -fno-builtin-malloc -fno-builtin-free -fno-builtin-realloc  -DLOG_INCLUDE_SOURCE_INFO=1 -DPARTICLE_USER_MODULE -DUSE_THREADING=0 -DUSE_SPI=SPI -DUSE_CS=A2 -DUSE_SPI=SPI -DUSE_CS=A2 -DUSE_THREADING=0 -DUSER_FIRMWARE_IMAGE_SIZE=0x20000 -DUSER_FIRMWARE_IMAGE_LOCATION=0x80A0000 -DMODULAR_FIRMWARE=1 -DMODULE_VERSION=4 -DMODULE_FUNCTION=5 -DMODULE_INDEX=1 -DMODULE_DEPENDENCY=4,2,108 -D_WINSOCK_H -D_GNU_SOURCE -DLOG_MODULE_CATEGORY="\"app\""  -Wno-pointer-sign -std=gnu99 -c -o ../build/target/user/platform-6-mAdafruit_GFX_RK/src/glcdfont.o lib/Adafruit_GFX_RK/src/glcdfont.c
+
+Building cpp file: src/emptyerror.cpp
+Invoking: ARM GCC CPP Compiler
+mkdir -p ../build/target/user/platform-6-msrc/
+arm-none-eabi-gcc -DSTM32_DEVICE -DSTM32F2XX -DPLATFORM_THREADING=1 -DPLATFORM_ID=6 -DPLATFORM_NAME=photon -DUSBD_VID_SPARK=0x2B04 -DUSBD_PID_DFU=0xD006 -DUSBD_PID_CDC=0xC006 -DSPARK_PLATFORM -g3 -gdwarf-2 -Os -mcpu=cortex-m3 -mthumb -DINCLUDE_PLATFORM=1 -DPRODUCT_ID=6 -DPRODUCT_FIRMWARE_VERSION=65535 -DUSE_STDPERIPH_DRIVER -DDFU_BUILD_ENABLE -DSYSTEM_VERSION_STRING=0.6.2 -DRELEASE_BUILD -I./inc -I../wiring/inc -I../system/inc -I../services/inc -I../communication/src -I../hal/inc -I../hal/shared -I../hal/src/photon -I../hal/src/stm32f2xx -I../hal/src/stm32 -I../hal/src/photon/api -I../platform/shared/inc -I../platform/MCU/STM32F2xx/STM32_USB_Host_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_OTG_Driver/inc -I../platform/MCU/STM32F2xx/STM32_StdPeriph_Driver/inc -I../platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc -I../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc -I../platform/MCU/shared/STM32/inc -I../platform/MCU/STM32F2xx/CMSIS/Include -I../platform/MCU/STM32F2xx/CMSIS/Device/ST/Include -I../dynalib/inc -Isrc -I./libraries -Isrc -Isrc -Isrc -Isrc -Ilib/Adafruit_GFX_RK/src -Ilib/Adafruit_LEDBackpack_RK/src -I. -MD -MP -MF ../build/target/user/platform-6-msrc/emptyerror.o.d -ffunction-sections -fdata-sections -Wall -Wno-switch -Wno-error=deprecated-declarations -fmessage-length=0 -fno-strict-aliasing -DSPARK=1 -DPARTICLE=1 -DSTART_DFU_FLASHER_SERIAL_SPEED=14400 -DSTART_YMODEM_FLASHER_SERIAL_SPEED=28800 -DSPARK_PLATFORM_NET=BCM9WCDUSI09 -fno-builtin-malloc -fno-builtin-free -fno-builtin-realloc  -DLOG_INCLUDE_SOURCE_INFO=1 -DPARTICLE_USER_MODULE -DUSE_THREADING=0 -DUSE_SPI=SPI -DUSE_CS=A2 -DUSE_SPI=SPI -DUSE_CS=A2 -DUSE_THREADING=0 -DUSER_FIRMWARE_IMAGE_SIZE=0x20000 -DUSER_FIRMWARE_IMAGE_LOCATION=0x80A0000 -DMODULAR_FIRMWARE=1 -DMODULE_VERSION=4 -DMODULE_FUNCTION=5 -DMODULE_INDEX=1 -DMODULE_DEPENDENCY=4,2,108 -D_WINSOCK_H -D_GNU_SOURCE -DLOG_MODULE_CATEGORY="\"app\""  -fno-exceptions -fno-rtti -fcheck-new -std=gnu++11 -c -o ../build/target/user/platform-6-msrc/emptyerror.o src/emptyerror.cpp
+In file included from lib/Adafruit_LEDBackpack_RK/src/Adafruit_LEDBackpack.h:24:0,
+                 from lib/Adafruit_LEDBackpack_RK/src/Adafruit_LEDBackpack_RK.h:4,
+                 from emptyerror.ino:3:
+lib/Adafruit_GFX_RK/src/Adafruit_GFX_RK.h:6:8: warning: extra tokens at end of #endif directive [enabled by default]
+ #endif __ADAFRUIT_GFX_RK_H
+        ^
+In file included from lib/Adafruit_LEDBackpack_RK/src/Adafruit_LEDBackpack_RK.h:4:0,
+                 from emptyerror.ino:3:
+lib/Adafruit_LEDBackpack_RK/src/Adafruit_LEDBackpack.h:29:0: warning: "LED_RED" redefined [enabled by default]
+ #define LED_RED 1
+ ^
+In file included from ../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h:32:0,
+                 from ../hal/src/stm32f2xx/platform_headers.h:17,
+                 from ./inc/application.h:36,
+                 from src/emptyerror.cpp:1:
+../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h:67:0: note: this is the location of the previous definition
+ #define LED_RED                             LED3
+ ^
+In file included from lib/Adafruit_LEDBackpack_RK/src/Adafruit_LEDBackpack_RK.h:4:0,
+                 from emptyerror.ino:3:
+lib/Adafruit_LEDBackpack_RK/src/Adafruit_LEDBackpack.h:31:0: warning: "LED_GREEN" redefined [enabled by default]
+ #define LED_GREEN 3
+ ^
+In file included from ../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h:32:0,
+                 from ../hal/src/stm32f2xx/platform_headers.h:17,
+                 from ./inc/application.h:36,
+                 from src/emptyerror.cpp:1:
+../platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h:74:0: note: this is the location of the previous definition
+ #define LED_GREEN                           LED4
+ ^
+emptyerror.ino: In function 'void loop()':
+emptyerror.ino:23:34: error: 'count' was not declared in this scope
+emptyerror.ino:27:5: error: 'count' was not declared in this scope
+../build/module.mk:267: recipe for target '../build/target/user/platform-6-msrc/emptyerror.o' failed
+make[2]: Leaving directory '/firmware/user'
+make[2]: *** [../build/target/user/platform-6-msrc/emptyerror.o] Error 1
+../../../build/recurse.mk:11: recipe for target 'user' failed
+make[1]: Leaving directory '/firmware/modules/photon/user-part'
+make[1]: *** [user] Error 2
+../build/recurse.mk:11: recipe for target 'modules/photon/user-part' failed
+make: *** [modules/photon/user-part] Error 2

--- a/spec/errors.spec.js
+++ b/spec/errors.spec.js
@@ -63,20 +63,43 @@ describe('parsing linker errors', function(){
 	});
 	it('should return an object', function(){
 		var output = parser.parseString(stdout);
+		i = 3;
+		output.length.should.equal(17);
+		output[i].type.should.equal('error');
+		output[i].subtype.should.equal('undefined reference');
+		output[i].filename.should.equal('/workspace/dispatcher.cpp');
+		output[i].line.should.equal(27);
+		output[i].column.should.equal(0);
+		output[i].text.should.equal('undefined reference to "vtable for Logger"');
+		output[i].affectedSymbol.should.equal('vtable for Logger');
+		output[i].parentFunction.should.equal('Dispatcher::setLog(Logger*)');
 
-		output.length.should.equal(14);
-		output[0].type.should.equal('error');
-		output[0].subtype.should.equal('undefined reference');
-		output[0].filename.should.equal('/workspace/dispatcher.cpp');
-		output[0].line.should.equal(27);
-		output[0].column.should.equal(0);
-		output[0].text.should.equal('undefined reference to "vtable for Logger"');
-		output[0].affectedSymbol.should.equal('vtable for Logger');
-		output[0].parentFunction.should.equal('Dispatcher::setLog(Logger*)');
+		i += 3;
+		output[i].subtype.should.equal('multiple definition');
+		output[i].parentFunction.should.equal('IntervalTimer::isAllocated_SIT()');
+		output[i].firstDefined.filename.should.equal('SparkIntervalTimer.cpp');
+		output[i].firstDefined.line.should.equal(61);
+	});
+});
 
-		output[3].subtype.should.equal('multiple definition');
-		output[3].parentFunction.should.equal('IntervalTimer::isAllocated_SIT()');
-		output[3].firstDefined.filename.should.equal('SparkIntervalTimer.cpp');
-		output[3].firstDefined.line.should.equal(61);
+describe('parsing 0.6.0 errors', function(){
+	var stdout = null;
+	before(function(){
+		stdout = fs.readFileSync(__dirname + '/8_dray_0.6.0.txt');
+	});
+	it('should return an object', function(){
+		var output = parser.parseString(stdout);
+
+		output.length.should.equal(7);
+		output[5].type.should.equal('error');
+		output[5].filename.should.equal('emptyerror.ino');
+		output[5].line.should.equal(23);
+		output[5].column.should.equal(34);
+		output[5].text.should.equal('\'count\' was not declared in this scope');
+		output[6].type.should.equal('error');
+		output[6].filename.should.equal('emptyerror.ino');
+		output[6].line.should.equal(27);
+		output[6].column.should.equal(5);
+		output[6].text.should.equal('\'count\' was not declared in this scope');
 	});
 });


### PR DESCRIPTION
Adds support for one line gcc errors like:

```
emptyerror.ino: In function 'void loop()':
emptyerror.ino:23:34: error: 'count' was not declared in this scope
emptyerror.ino:27:5: error: 'count' was not declared in this scope
```

This fixes #2 as well